### PR TITLE
Enhance Our Products: Keep ecosystem block + new products

### DIFF
--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -29,6 +29,15 @@
 .opensource-desc{color:rgba(255,255,255,.5);font-size:.85rem;line-height:1.4}
 .opensource-lang{background-color:rgba(39,174,96,.2);color:#27ae60;padding:2px 10px;border-radius:10px;font-size:.7rem;font-weight:600;white-space:nowrap}
 @media(max-width:768px){.opensource-list{grid-template-columns:1fr}}
+.ecosystem-block{padding:1.5rem;margin-bottom:1.5rem;background-color:rgba(39,174,96,.06);border:1px solid rgba(39,174,96,.35);border-radius:12px}
+.ecosystem-header{display:flex;align-items:center;justify-content:space-between;gap:.5rem;margin-bottom:.5rem}
+.ecosystem-title{color:#27ae60;font-weight:700;font-size:1.25rem;text-decoration:none}
+.ecosystem-title:hover{color:#2ecc71}
+.ecosystem-desc{color:rgba(255,255,255,.6);font-size:.9rem;line-height:1.5;margin-bottom:1.25rem}
+.ecosystem-components{display:grid;grid-template-columns:repeat(2,1fr);gap:.75rem}
+.ecosystem-component{display:flex;flex-direction:column;padding:1rem 1.25rem;background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-radius:8px;text-decoration:none;transition:all .2s ease;gap:.5rem}
+.ecosystem-component:hover{background-color:rgba(39,174,96,.1);border-color:rgba(39,174,96,.4);transform:translateY(-2px);box-shadow:0 4px 12px rgba(39,174,96,.15)}
+@media(max-width:768px){.ecosystem-components{grid-template-columns:1fr}}
 .contribution-header{display:flex;justify-content:space-between;align-items:center;padding:1rem 1.5rem;background-color:rgba(39,174,96,.1);border:1px solid rgba(39,174,96,.3);border-radius:8px;cursor:pointer;transition:all .3s ease}
 .contribution-header:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important}
 .contribution-items{background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding:1rem 1.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.75rem}

--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -38,6 +38,9 @@
 .ecosystem-component{display:flex;flex-direction:column;padding:1rem 1.25rem;background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-radius:8px;text-decoration:none;transition:all .2s ease;gap:.5rem}
 .ecosystem-component:hover{background-color:rgba(39,174,96,.1);border-color:rgba(39,174,96,.4);transform:translateY(-2px);box-shadow:0 4px 12px rgba(39,174,96,.15)}
 @media(max-width:768px){.ecosystem-components{grid-template-columns:1fr}}
+.product-group-label{color:rgba(255,255,255,.85);font-size:1rem;font-weight:600;letter-spacing:.03em;text-transform:uppercase;margin:1.75rem 0 .9rem}
+.products-cta{display:inline-flex;align-items:center;gap:.4rem;color:#27ae60;font-weight:600;text-decoration:none;padding:.6rem 1.25rem;border:1px solid rgba(39,174,96,.4);border-radius:8px;transition:all .2s ease}
+.products-cta:hover{background-color:rgba(39,174,96,.12);border-color:rgba(39,174,96,.6);color:#2ecc71;transform:translateY(-2px)}
 .contribution-header{display:flex;justify-content:space-between;align-items:center;padding:1rem 1.5rem;background-color:rgba(39,174,96,.1);border:1px solid rgba(39,174,96,.3);border-radius:8px;cursor:pointer;transition:all .3s ease}
 .contribution-header:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important}
 .contribution-items{background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding:1rem 1.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.75rem}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -65,12 +65,12 @@
                 { name: "BDK - Replace Examples with Rustdoc", url: "https://github.com/bitcoindevkit/bdk/pull/2006" },
                 { name: "DLC Dev Kit - Oracle Announcement Creation", url: "https://github.com/bennyhodl/dlcdevkit/pull/104" }
             ],
-            "Nostr Protocol": [
+            "Nostr Apps": [
                 { name: "Amber - Export All Accounts Feature", url: "https://github.com/greenart7c3/Amber/pull/255" },
                 { name: "Routstr Core - Fix USD Pricing Fees", url: "https://github.com/Routstr/routstr-core/pull/189" },
                 { name: "Routstr Chat - Invoice History & Persistence", url: "https://github.com/Routstr/routstr-chat/pull/67" }
             ],
-            "Developer Tools & AI": [
+            "AI Developer Tools": [
                 { name: "Goose - Enable Zero-Config Providers in GUI", url: "https://github.com/block/goose/pull/3378" },
                 { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" }
             ],

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -27,23 +27,23 @@
         ecosystems: [
             {
                 name: "Keep Ecosystem",
-                description: "Self-custodial key management for Nostr and Bitcoin, built on FROST threshold signing across every form factor.",
+                description: "Self-custodial key management for Nostr and Bitcoin. An encrypted vault with FROST threshold signing and NIP-46 remote signing, spanning CLI, desktop, mobile, hardware, and cloud enclaves so no single device ever holds the whole key.",
                 url: "https://github.com/privkeyio/keep",
                 components: [
-                    { name: "Keep", role: "Core signing daemon", language: "Rust", url: "https://github.com/privkeyio/keep" },
-                    { name: "Keep Android", role: "NIP-55 mobile signer", language: "Kotlin", url: "https://github.com/privkeyio/keep-android" },
-                    { name: "Keep ESP32", role: "Air-gapped signing device", language: "C", url: "https://github.com/privkeyio/keep-esp32" },
-                    { name: "Keep StartOS", role: "Self-hosted node package", language: "TypeScript", url: "https://github.com/privkeyio/keep-startos" }
+                    { name: "Keep", role: "Encrypted vault: CLI, desktop app & Nitro Enclave signing", language: "Rust", url: "https://github.com/privkeyio/keep" },
+                    { name: "Keep Android", role: "FROST mobile signer with NIP-55 and NIP-46", language: "Kotlin", url: "https://github.com/privkeyio/keep-android" },
+                    { name: "Keep ESP32", role: "Air-gapped ESP32-S3 hardware signer", language: "C", url: "https://github.com/privkeyio/keep-esp32" },
+                    { name: "Keep StartOS", role: "Always-on FROST co-signer node", language: "TypeScript", url: "https://github.com/privkeyio/keep-startos" }
                 ]
             }
         ],
         products: [
-            { name: "libnostr-c", description: "Lightweight, portable C library for the Nostr protocol with native Lightning Network integration.", language: "C", url: "https://github.com/privkeyio/libnostr-c" },
-            { name: "libnostr-z", description: "Zig library for the Nostr protocol.", language: "Zig", url: "https://github.com/privkeyio/libnostr-z" },
-            { name: "wisp", description: "A lightweight Nostr relay you can self-host.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
-            { name: "puck", description: "Nostr Wallet Connect server for linking wallets to apps.", language: "Zig", url: "https://github.com/privkeyio/puck" },
-            { name: "whisper", description: "Encrypted Nostr DM pipe for secure messaging transport.", language: "C", url: "https://github.com/privkeyio/whisper" },
-            { name: "Taproot Assets Gateway", description: "REST proxy for Taproot Assets.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
+            { name: "libnostr-c", description: "Portable C library for Nostr with NIP-44 encryption, Lightning zaps, and full relay-side support for embedded systems.", language: "C", url: "https://github.com/privkeyio/libnostr-c" },
+            { name: "libnostr-z", description: "Zig library for the Nostr protocol with broad NIP coverage, from events and relays to NIP-46 signing and NWC.", language: "Zig", url: "https://github.com/privkeyio/libnostr-z" },
+            { name: "wisp", description: "Fast, lightweight self-hostable Nostr relay with spider mode that syncs notes from people you follow.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
+            { name: "puck", description: "Nostr Wallet Connect (NIP-47) server with an LNbits backend for invoices and payments.", language: "Zig", url: "https://github.com/privkeyio/puck" },
+            { name: "whisper", description: "Encrypted Nostr DM pipe (NIP-17 + NIP-44) with a Unix-style CLI and TUI.", language: "C", url: "https://github.com/privkeyio/whisper" },
+            { name: "Taproot Assets Gateway", description: "REST proxy that makes Lightning Labs' tapd usable from web apps with CORS and simplified macaroon auth.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
         ],
         contributions: {
             "Bitcoin Wallets": [

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -49,13 +49,11 @@
             "Bitcoin Wallets": [
                 { name: "Sparrow - Hide Amounts (v2.3.1)", url: "https://github.com/sparrowwallet/sparrow/releases/tag/2.3.1" },
                 { name: "Liana - User-Agent Header Support", url: "https://github.com/wizardsardine/liana/pull/1902" },
-                { name: "Zeus - Reload Invoice on Restart", url: "https://github.com/ZeusLN/zeus/pull/3380" },
-                { name: "Bull Bitcoin - Hide Exchange Features", url: "https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/1345" }
+                { name: "Zeus - Reload Invoice on Restart", url: "https://github.com/ZeusLN/zeus/pull/3380" }
             ],
             "Bitcoin Infrastructure": [
                 { name: "Bitcoin Knots - v29.3.knots20260508 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508" },
                 { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" },
-                { name: "OCEAN - Job Coordination for Fallback Shares", url: "https://github.com/OCEAN-xyz/datum_gateway/pull/156" },
                 { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" }
             ],
             "SDKs & Libraries": [
@@ -70,8 +68,7 @@
             ],
             "Developer Tools & AI": [
                 { name: "Goose - Enable Zero-Config Providers in GUI", url: "https://github.com/block/goose/pull/3378" },
-                { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" },
-                { name: "Goose - Middle-Out Message Compression", url: "https://github.com/block/goose/pull/3907" }
+                { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" }
             ],
         },
         team: [

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -24,13 +24,26 @@
             { icon: "pe-7s-config", title: "AI + Policy", description: "AI agents need guardrails. We build signing with policy controls." },
             { icon: "pe-7s-key", title: "Self-Sovereign", description: "Own your data, identity, and money without third-party custody." }
         ],
+        ecosystems: [
+            {
+                name: "Keep Ecosystem",
+                description: "Self-custodial key management for Nostr and Bitcoin, built on FROST threshold signing across every form factor.",
+                url: "https://github.com/privkeyio/keep",
+                components: [
+                    { name: "Keep", role: "Core signing daemon", language: "Rust", url: "https://github.com/privkeyio/keep" },
+                    { name: "Keep Android", role: "NIP-55 mobile signer", language: "Kotlin", url: "https://github.com/privkeyio/keep-android" },
+                    { name: "Keep ESP32", role: "Air-gapped signing device", language: "C", url: "https://github.com/privkeyio/keep-esp32" },
+                    { name: "Keep StartOS", role: "Self-hosted node package", language: "TypeScript", url: "https://github.com/privkeyio/keep-startos" }
+                ]
+            }
+        ],
         products: [
             { name: "libnostr-c", description: "Lightweight, portable C library for the Nostr protocol with native Lightning Network integration.", language: "C", url: "https://github.com/privkeyio/libnostr-c" },
-            { name: "Taproot Assets Gateway", description: "REST proxy for Taproot Assets.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" },
             { name: "libnostr-z", description: "Zig library for the Nostr protocol.", language: "Zig", url: "https://github.com/privkeyio/libnostr-z" },
-            { name: "Keep", description: "Sovereign key management for Nostr and Bitcoin.", language: "Rust", url: "https://github.com/privkeyio/keep" },
-            { name: "Keep ESP32", description: "ESP32-S3 air-gapped FROST threshold signing device for Nostr and Bitcoin.", language: "C", url: "https://github.com/privkeyio/keep-esp32" },
-            { name: "Keep Android", description: "Android app for FROST threshold signing with NIP-55 support.", language: "Kotlin", url: "https://github.com/privkeyio/keep-android" }
+            { name: "wisp", description: "A lightweight Nostr relay you can self-host.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
+            { name: "puck", description: "Nostr Wallet Connect server for linking wallets to apps.", language: "Zig", url: "https://github.com/privkeyio/puck" },
+            { name: "whisper", description: "Encrypted Nostr DM pipe for secure messaging transport.", language: "C", url: "https://github.com/privkeyio/whisper" },
+            { name: "Taproot Assets Gateway", description: "REST proxy for Taproot Assets.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
         ],
         contributions: {
             "Bitcoin & Lightning Network": [
@@ -123,6 +136,24 @@
     function renderProducts() {
         document.getElementById('products-grid').innerHTML = `
             <div class="col-lg-10">
+                ${DATA.ecosystems.map(e => `
+                    <div class="ecosystem-block">
+                        <div class="ecosystem-header">
+                            <a href="${e.url}" target="_blank" rel="noopener noreferrer" class="ecosystem-title">${e.name}</a>
+                            <span class="opensource-lang">Ecosystem</span>
+                        </div>
+                        <p class="ecosystem-desc">${e.description}</p>
+                        <div class="ecosystem-components">
+                            ${e.components.map(c => `
+                                <a href="${c.url}" target="_blank" rel="noopener noreferrer" class="ecosystem-component">
+                                    <div class="opensource-item-header">
+                                        <span class="opensource-name">${c.name}</span>
+                                        <span class="opensource-lang">${c.language}</span>
+                                    </div>
+                                    <span class="opensource-desc">${c.role}</span>
+                                </a>`).join('')}
+                        </div>
+                    </div>`).join('')}
                 <div class="opensource-list">
                     ${DATA.products.map(p => `
                         <a href="${p.url}" target="_blank" rel="noopener noreferrer" class="opensource-item">

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -46,14 +46,22 @@
             { name: "Taproot Assets Gateway", description: "REST proxy for Taproot Assets.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
         ],
         contributions: {
-            "Bitcoin & Lightning Network": [
-                { name: "Bitcoin Knots - v29.3.knots20260508 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508" },
-                { name: "Rust Miniscript - Taptree-Native Policy Compilation", url: "https://github.com/rust-bitcoin/rust-miniscript/pull/906" },
+            "Bitcoin Wallets": [
                 { name: "Sparrow - Hide Amounts (v2.3.1)", url: "https://github.com/sparrowwallet/sparrow/releases/tag/2.3.1" },
-                { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" },
-                { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" },
                 { name: "Liana - User-Agent Header Support", url: "https://github.com/wizardsardine/liana/pull/1902" },
-                { name: "OCEAN - Job Coordination for Fallback Shares", url: "https://github.com/OCEAN-xyz/datum_gateway/pull/156" }
+                { name: "Zeus - Reload Invoice on Restart", url: "https://github.com/ZeusLN/zeus/pull/3380" },
+                { name: "Bull Bitcoin - Hide Exchange Features", url: "https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/1345" }
+            ],
+            "Bitcoin Infrastructure": [
+                { name: "Bitcoin Knots - v29.3.knots20260508 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508" },
+                { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" },
+                { name: "OCEAN - Job Coordination for Fallback Shares", url: "https://github.com/OCEAN-xyz/datum_gateway/pull/156" },
+                { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" }
+            ],
+            "SDKs & Libraries": [
+                { name: "Rust Miniscript - Taptree-Native Policy Compilation", url: "https://github.com/rust-bitcoin/rust-miniscript/pull/906" },
+                { name: "BDK - Replace Examples with Rustdoc", url: "https://github.com/bitcoindevkit/bdk/pull/2006" },
+                { name: "DLC Dev Kit - Oracle Announcement Creation", url: "https://github.com/bennyhodl/dlcdevkit/pull/104" }
             ],
             "Nostr Protocol": [
                 { name: "Amber - Export All Accounts Feature", url: "https://github.com/greenart7c3/Amber/pull/255" },
@@ -64,12 +72,6 @@
                 { name: "Goose - Enable Zero-Config Providers in GUI", url: "https://github.com/block/goose/pull/3378" },
                 { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" },
                 { name: "Goose - Middle-Out Message Compression", url: "https://github.com/block/goose/pull/3907" }
-            ],
-            "Wallets & SDKs": [
-                { name: "Zeus - Reload Invoice on Restart", url: "https://github.com/ZeusLN/zeus/pull/3380" },
-                { name: "Bull Bitcoin - Hide Exchange Features", url: "https://github.com/SatoshiPortal/bullbitcoin-mobile/pull/1345" },
-                { name: "BDK - Replace Examples with Rustdoc", url: "https://github.com/bitcoindevkit/bdk/pull/2006" },
-                { name: "DLC Dev Kit - Oracle Announcement Creation", url: "https://github.com/bennyhodl/dlcdevkit/pull/104" }
             ],
         },
         team: [

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -37,14 +37,18 @@
                 ]
             }
         ],
-        products: [
-            { name: "libnostr-c", description: "Portable C library for Nostr with NIP-44 encryption, Lightning zaps, and full relay-side support for embedded systems.", language: "C", url: "https://github.com/privkeyio/libnostr-c" },
-            { name: "libnostr-z", description: "Zig library for the Nostr protocol with broad NIP coverage, from events and relays to NIP-46 signing and NWC.", language: "Zig", url: "https://github.com/privkeyio/libnostr-z" },
-            { name: "wisp", description: "Fast, lightweight self-hostable Nostr relay with spider mode that syncs notes from people you follow.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
-            { name: "puck", description: "Nostr Wallet Connect (NIP-47) server with an LNbits backend for invoices and payments.", language: "Zig", url: "https://github.com/privkeyio/puck" },
-            { name: "whisper", description: "Encrypted Nostr DM pipe (NIP-17 + NIP-44) with a Unix-style CLI and TUI.", language: "C", url: "https://github.com/privkeyio/whisper" },
-            { name: "Taproot Assets Gateway", description: "REST proxy that makes Lightning Labs' tapd usable from web apps with CORS and simplified macaroon auth.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
-        ],
+        products: {
+            "Libraries": [
+                { name: "libnostr-c", description: "Portable C library for Nostr with NIP-44 encryption, Lightning zaps, and full relay-side support for embedded systems.", language: "C", url: "https://github.com/privkeyio/libnostr-c" },
+                { name: "libnostr-z", description: "Zig library for the Nostr protocol with broad NIP coverage, from events and relays to NIP-46 signing and NWC.", language: "Zig", url: "https://github.com/privkeyio/libnostr-z" }
+            ],
+            "Apps & Tools": [
+                { name: "wisp", description: "Fast, lightweight self-hostable Nostr relay with spider mode that syncs notes from people you follow.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
+                { name: "puck", description: "Nostr Wallet Connect (NIP-47) server with an LNbits backend for invoices and payments.", language: "Zig", url: "https://github.com/privkeyio/puck" },
+                { name: "whisper", description: "Encrypted Nostr DM pipe (NIP-17 + NIP-44) with a Unix-style CLI and TUI.", language: "C", url: "https://github.com/privkeyio/whisper" },
+                { name: "Taproot Assets Gateway", description: "REST proxy that makes Lightning Labs' tapd usable from web apps with CORS and simplified macaroon auth.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
+            ]
+        },
         contributions: {
             "Bitcoin Wallets": [
                 { name: "Sparrow - Hide Amounts (v2.3.1)", url: "https://github.com/sparrowwallet/sparrow/releases/tag/2.3.1" },
@@ -56,7 +60,7 @@
                 { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" },
                 { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" }
             ],
-            "SDKs & Libraries": [
+            "Bitcoin Libraries": [
                 { name: "Rust Miniscript - Taptree-Native Policy Compilation", url: "https://github.com/rust-bitcoin/rust-miniscript/pull/906" },
                 { name: "BDK - Replace Examples with Rustdoc", url: "https://github.com/bitcoindevkit/bdk/pull/2006" },
                 { name: "DLC Dev Kit - Oracle Announcement Creation", url: "https://github.com/bennyhodl/dlcdevkit/pull/104" }
@@ -153,20 +157,29 @@
                                 </a>`).join('')}
                         </div>
                     </div>`).join('')}
-                <div class="opensource-list">
-                    ${DATA.products.map(p => `
-                        <a href="${p.url}" target="_blank" rel="noopener noreferrer" class="opensource-item">
-                            <div class="opensource-item-header">
-                                <span class="opensource-name">${p.name}</span>
-                                <span class="opensource-lang">${p.language}</span>
-                            </div>
-                            <span class="opensource-desc">${p.description}</span>
-                        </a>`).join('')}
+                ${Object.entries(DATA.products).map(([group, items]) => `
+                    <h4 class="product-group-label">${group}</h4>
+                    <div class="opensource-list">
+                        ${items.map(p => `
+                            <a href="${p.url}" target="_blank" rel="noopener noreferrer" class="opensource-item">
+                                <div class="opensource-item-header">
+                                    <span class="opensource-name">${p.name}</span>
+                                    <span class="opensource-lang">${p.language}</span>
+                                </div>
+                                <span class="opensource-desc">${p.description}</span>
+                            </a>`).join('')}
+                    </div>`).join('')}
+                <div class="text-center mt-4">
+                    <a href="https://github.com/privkeyio" target="_blank" rel="noopener noreferrer" class="products-cta">Explore all our open source work <i class="mdi mdi-arrow-right"></i></a>
                 </div>
             </div>`;
     }
 
     function renderContributions() {
+        const all = Object.values(DATA.contributions).flat();
+        const projects = new Set(all.map(c => c.name.split(' - ')[0]));
+        document.getElementById('contributions-stat').textContent =
+            `${all.length} merged contributions across ${projects.size} open-source projects`;
         const container = document.getElementById('contributions-accordion');
         container.innerHTML = Object.entries(DATA.contributions).map(([category, items]) => `
             <div style="margin-bottom:1rem">

--- a/index.html
+++ b/index.html
@@ -175,7 +175,8 @@
                     <div class="row mt-4 justify-content-center" id="products-grid"></div>
                     <div class="row mt-5 justify-content-center">
                         <div class="col-lg-10">
-                            <h3 class="text-white text-center mb-4">Community Contributions</h3>
+                            <h3 class="text-white text-center mb-2">Community Contributions</h3>
+                            <p id="contributions-stat" class="text-center text-white-50"></p>
                             <div id="contributions-accordion" style="margin-top:2rem"></div>
                         </div>
                     </div>


### PR DESCRIPTION
Restructure the Products section to present Keep as a grouped ecosystem and surface more first-party repos.

## Changes
- **Keep Ecosystem block**: Keep is now presented as an ecosystem with its components grouped: Keep (core daemon), Keep Android (NIP-55 signer), Keep ESP32 (air-gapped device), and Keep StartOS (self-hosted node package).
- **New products**: added wisp (Nostr relay), puck (NWC server), and whisper (encrypted DM pipe).
- **Reordering**: libnostr-c and libnostr-z moved to the top of the standalone product list.
- Added `.ecosystem-block` styling reusing the existing green theme.