### PR TITLE
Expand Knots release into PR dropdown and order contributions by value

### DIFF
--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -46,6 +46,12 @@
 .contribution-items{background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding:1rem 1.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.75rem}
 .contribution-link{display:flex;align-items:center;padding:.75rem 1rem;background-color:rgba(255,255,255,.08);border:1px solid rgba(39,174,96,.2);border-radius:6px;text-decoration:none;color:#27ae60;transition:all .2s ease;font-size:.95rem;font-weight:500}
 .contribution-link:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important;transform:translateX(4px);color:#27ae60}
+.contribution-subgroup{grid-column:1/-1}
+.contribution-subtoggle{cursor:pointer}
+.contribution-subname{color:#27ae60;text-decoration:none}
+.contribution-subname:hover{color:#27ae60;text-decoration:underline}
+.contribution-subitems{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.5rem;margin:.5rem 0 0 1.5rem;padding-left:1rem;border-left:2px solid rgba(39,174,96,.25)}
+.contribution-sublink{font-size:.85rem;font-weight:400;background-color:rgba(255,255,255,.04)}
 .resource-card{background-color:rgba(255,255,255,.1);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.1);cursor:pointer;transition:all .4s cubic-bezier(.25,.8,.25,1)}
 .resource-card:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 20px 40px rgba(39,174,96,.3),0 0 20px rgba(39,174,96,.2);background-color:rgba(255,255,255,.15)!important;border-color:rgba(39,174,96,.5)!important}
 @media(max-width:768px){.hero-stats{flex-direction:column;gap:1rem}.hero-stats .stat-item{min-width:200px}.stats-bar{flex-direction:column;gap:1.5rem}.contribution-items{grid-template-columns:1fr}}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -50,20 +50,32 @@
             ]
         },
         contributions: {
-            "Bitcoin Wallets": [
-                { name: "Sparrow - Hide Amounts (v2.3.1)", url: "https://github.com/sparrowwallet/sparrow/releases/tag/2.3.1" },
-                { name: "Liana - User-Agent Header Support", url: "https://github.com/wizardsardine/liana/pull/1902" },
-                { name: "Zeus - Reload Invoice on Restart", url: "https://github.com/ZeusLN/zeus/pull/3380" }
-            ],
             "Bitcoin Infrastructure": [
-                { name: "Bitcoin Knots - v29.3.knots20260508 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508" },
-                { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" },
-                { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" }
+                { name: "Bitcoin Knots - v29.3.knots20260508 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508", subItems: [
+                    { name: "Policy: Penalize effective fee for sub-dust outputs", url: "https://github.com/bitcoinknots/bitcoin/pull/272" },
+                    { name: "rpc: add segwit and taproot support to sweepprivkeys", url: "https://github.com/bitcoinknots/bitcoin/pull/296" },
+                    { name: "qt: Add sweep private key dialog", url: "https://github.com/bitcoinknots/bitcoin/pull/297" },
+                    { name: "codex32: early return on validation error to prevent OOB read", url: "https://github.com/bitcoinknots/bitcoin/pull/267" },
+                    { name: "blockstorage: fix unsigned underflow in GetBlockFileInfo bounds check", url: "https://github.com/bitcoinknots/bitcoin/pull/294" },
+                    { name: "Saturate CalculateExtraTxWeight and cap GUI datacarriercost to 1024", url: "https://github.com/bitcoinknots/bitcoin/pull/268" },
+                    { name: "external_signer: validate fingerprint is hex before shell command use", url: "https://github.com/bitcoinknots/bitcoin/pull/266" },
+                    { name: "feat(qt): add /clearhistory command", url: "https://github.com/bitcoinknots/bitcoin/pull/214" },
+                    { name: "qt: warn when script threads exceed CPU cores", url: "https://github.com/bitcoinknots/bitcoin/pull/287" },
+                    { name: "GUI: Port Windows taskbar progress to COM", url: "https://github.com/bitcoinknots/bitcoin/pull/215" },
+                    { name: "init: improve error message when index needs pruned block data", url: "https://github.com/bitcoinknots/bitcoin/pull/262" }
+                ] },
+                { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" },
+                { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" }
             ],
             "Bitcoin Libraries": [
                 { name: "Rust Miniscript - Taptree-Native Policy Compilation", url: "https://github.com/rust-bitcoin/rust-miniscript/pull/906" },
-                { name: "BDK - Replace Examples with Rustdoc", url: "https://github.com/bitcoindevkit/bdk/pull/2006" },
-                { name: "DLC Dev Kit - Oracle Announcement Creation", url: "https://github.com/bennyhodl/dlcdevkit/pull/104" }
+                { name: "DLC Dev Kit - Oracle Announcement Creation", url: "https://github.com/bennyhodl/dlcdevkit/pull/104" },
+                { name: "BDK - Replace Examples with Rustdoc", url: "https://github.com/bitcoindevkit/bdk/pull/2006" }
+            ],
+            "Bitcoin Wallets": [
+                { name: "Sparrow - Hide Amounts (v2.3.1)", url: "https://github.com/sparrowwallet/sparrow/releases/tag/2.3.1" },
+                { name: "Zeus - Reload Invoice on Restart", url: "https://github.com/ZeusLN/zeus/pull/3380" },
+                { name: "Liana - User-Agent Header Support", url: "https://github.com/wizardsardine/liana/pull/1902" }
             ],
             "Nostr Apps": [
                 { name: "Amber - Export All Accounts Feature", url: "https://github.com/greenart7c3/Amber/pull/255" },
@@ -71,8 +83,8 @@
                 { name: "Routstr Chat - Invoice History & Persistence", url: "https://github.com/Routstr/routstr-chat/pull/67" }
             ],
             "AI Developer Tools": [
-                { name: "Goose - Enable Zero-Config Providers in GUI", url: "https://github.com/block/goose/pull/3378" },
-                { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" }
+                { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" },
+                { name: "Goose - Enable Zero-Config Providers in GUI", url: "https://github.com/block/goose/pull/3378" }
             ],
         },
         team: [
@@ -179,7 +191,7 @@
         const all = Object.values(DATA.contributions).flat();
         const projects = new Set(all.map(c => c.name.split(' - ')[0]));
         document.getElementById('contributions-stat').textContent =
-            `${all.length} merged contributions across ${projects.size} open-source projects`;
+            `${all.length} contributions shipped across ${projects.size} open-source projects`;
         const container = document.getElementById('contributions-accordion');
         container.innerHTML = Object.entries(DATA.contributions).map(([category, items]) => `
             <div style="margin-bottom:1rem">
@@ -188,7 +200,17 @@
                     <i class="mdi mdi-chevron-down" style="color:#27ae60;font-size:1.5rem"></i>
                 </div>
                 <div class="contribution-items" data-category="${category}" style="display:none">
-                    ${items.map(c => `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
+                    ${items.map(c => c.subItems ? `<div class="contribution-subgroup">
+                        <div class="contribution-link contribution-subtoggle" data-sub="${category}">
+                            <i class="mdi mdi-github" style="margin-right:0.5rem"></i>
+                            <a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-subname">${c.name}</a>
+                            <small class="text-white-50" style="margin-left:auto;margin-right:0.5rem">${c.subItems.length} PRs</small>
+                            <i class="mdi mdi-chevron-down sub-chevron"></i>
+                        </div>
+                        <div class="contribution-subitems" data-sub="${category}" style="display:none">
+                            ${c.subItems.map(s => `<a href="${s.url}" target="_blank" rel="noopener noreferrer" class="contribution-link contribution-sublink"><i class="mdi mdi-source-pull" style="margin-right:0.5rem"></i><span>${s.name}</span></a>`).join('')}
+                        </div>
+                    </div>` : `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
                 </div>
             </div>`).join('');
         container.querySelectorAll('.contribution-header').forEach(header => {
@@ -200,6 +222,18 @@
                 container.querySelectorAll('.contribution-items').forEach(el => el.style.display = 'none');
                 container.querySelectorAll('.contribution-header i').forEach(el => el.className = 'mdi mdi-chevron-down');
                 if (!isOpen) { items.style.display = 'grid'; icon.className = 'mdi mdi-chevron-up'; }
+            });
+        });
+        container.querySelectorAll('.contribution-subname').forEach(link => {
+            link.addEventListener('click', e => e.stopPropagation());
+        });
+        container.querySelectorAll('.contribution-subtoggle').forEach(toggle => {
+            toggle.addEventListener('click', () => {
+                const sub = toggle.parentElement.querySelector('.contribution-subitems');
+                const chevron = toggle.querySelector('.sub-chevron');
+                const isOpen = sub.style.display !== 'none';
+                sub.style.display = isOpen ? 'none' : 'grid';
+                chevron.className = isOpen ? 'mdi mdi-chevron-down sub-chevron' : 'mdi mdi-chevron-up sub-chevron';
             });
         });
     }


### PR DESCRIPTION
## Summary
- Expand the Bitcoin Knots v29.3.knots20260508 entry into an opt-in dropdown listing the 11 individual PRs, collapsed by default. The top-level entry still links to the release and counts as a single contribution, so the stat is not skewed.
- Order categories and items within each by value: consensus/security/protocol work and shipped user-facing features rank above docs, tooling, and minor UX.
- Order the 11 Knots PRs by value (sub-dust fee penalty and sweepprivkeys features first, security fixes next, GUI polish and docs last).
- Change stat wording from "merged contributions" to "shipped across" for accuracy: the Knots changes were hand-applied by the maintainer (PRs show closed, not GitHub-merged) and Sparrow shipped as a release, so "merged" overstated two entries.

## Notes
- All 11 Knots changes verified present in the v29.3.knots20260508 release tag.
- `node --check` passes on `assets/js/main.js`.