### PR TITLE
Fix contributions section layout: even boxes and full-width Knots PR panel

### DIFF
--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -43,15 +43,17 @@
 .products-cta:hover{background-color:rgba(39,174,96,.12);border-color:rgba(39,174,96,.6);color:#2ecc71;transform:translateY(-2px)}
 .contribution-header{display:flex;justify-content:space-between;align-items:center;padding:1rem 1.5rem;background-color:rgba(39,174,96,.1);border:1px solid rgba(39,174,96,.3);border-radius:8px;cursor:pointer;transition:all .3s ease}
 .contribution-header:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important}
-.contribution-items{background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding:1rem 1.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.75rem}
+.contribution-items{background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding:1rem 1.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.75rem;align-items:stretch}
 .contribution-link{display:flex;align-items:center;padding:.75rem 1rem;background-color:rgba(255,255,255,.08);border:1px solid rgba(39,174,96,.2);border-radius:6px;text-decoration:none;color:#27ae60;transition:all .2s ease;font-size:.95rem;font-weight:500}
 .contribution-link:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important;transform:translateX(4px);color:#27ae60}
-.contribution-subgroup{grid-column:1/-1}
 .contribution-subtoggle{cursor:pointer}
+.sub-count{margin-left:auto;margin-right:.5rem;font-size:.7rem;font-weight:600;white-space:nowrap;color:#27ae60;background-color:rgba(39,174,96,.15);border:1px solid rgba(39,174,96,.35);border-radius:999px;padding:.15rem .55rem;line-height:1}
 .contribution-subname{color:#27ae60;text-decoration:none}
 .contribution-subname:hover{color:#27ae60;text-decoration:underline}
-.contribution-subitems{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.5rem;margin:.5rem 0 0 1.5rem;padding-left:1rem;border-left:2px solid rgba(39,174,96,.25)}
-.contribution-sublink{font-size:.85rem;font-weight:400;background-color:rgba(255,255,255,.04)}
+.contribution-subpanel{grid-column:1/-1;background-color:rgba(255,255,255,.04);border:1px solid rgba(39,174,96,.2);border-radius:6px;padding:1rem 1.25rem}
+.contribution-subpanel-title{color:#27ae60;font-weight:600;font-size:.9rem;margin-bottom:.75rem}
+.contribution-subpanel-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:.5rem;align-items:stretch}
+.contribution-sublink{font-size:.85rem;font-weight:400;background-color:rgba(255,255,255,.06)}
 .resource-card{background-color:rgba(255,255,255,.1);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.1);cursor:pointer;transition:all .4s cubic-bezier(.25,.8,.25,1)}
 .resource-card:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 20px 40px rgba(39,174,96,.3),0 0 20px rgba(39,174,96,.2);background-color:rgba(255,255,255,.15)!important;border-color:rgba(39,174,96,.5)!important}
 @media(max-width:768px){.hero-stats{flex-direction:column;gap:1rem}.hero-stats .stat-item{min-width:200px}.stats-bar{flex-direction:column;gap:1.5rem}.contribution-items{grid-template-columns:1fr}}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,7 +51,7 @@
         },
         contributions: {
             "Bitcoin Infrastructure": [
-                { name: "Bitcoin Knots - v29.3.knots20260508 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508", subItems: [
+                { name: "Bitcoin Knots - v29.3 Release", url: "https://github.com/bitcoinknots/bitcoin/releases/tag/v29.3.knots20260508", subItems: [
                     { name: "Policy: Penalize effective fee for sub-dust outputs", url: "https://github.com/bitcoinknots/bitcoin/pull/272" },
                     { name: "rpc: add segwit and taproot support to sweepprivkeys", url: "https://github.com/bitcoinknots/bitcoin/pull/296" },
                     { name: "qt: Add sweep private key dialog", url: "https://github.com/bitcoinknots/bitcoin/pull/297" },
@@ -200,17 +200,18 @@
                     <i class="mdi mdi-chevron-down" style="color:#27ae60;font-size:1.5rem"></i>
                 </div>
                 <div class="contribution-items" data-category="${category}" style="display:none">
-                    ${items.map(c => c.subItems ? `<div class="contribution-subgroup">
-                        <div class="contribution-link contribution-subtoggle" data-sub="${category}">
+                    ${items.map((c, i) => c.subItems ? `<div class="contribution-link contribution-subtoggle" data-sub="${category}::${i}">
                             <i class="mdi mdi-github" style="margin-right:0.5rem"></i>
                             <a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-subname">${c.name}</a>
-                            <small class="text-white-50" style="margin-left:auto;margin-right:0.5rem">${c.subItems.length} PRs</small>
+                            <span class="sub-count">${c.subItems.length} PRs</span>
                             <i class="mdi mdi-chevron-down sub-chevron"></i>
-                        </div>
-                        <div class="contribution-subitems" data-sub="${category}" style="display:none">
-                            ${c.subItems.map(s => `<a href="${s.url}" target="_blank" rel="noopener noreferrer" class="contribution-link contribution-sublink"><i class="mdi mdi-source-pull" style="margin-right:0.5rem"></i><span>${s.name}</span></a>`).join('')}
-                        </div>
-                    </div>` : `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
+                        </div>` : `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
+                    ${items.map((c, i) => c.subItems ? `<div class="contribution-subpanel" data-sub="${category}::${i}" style="display:none">
+                            <div class="contribution-subpanel-title">${c.subItems.length} PRs in Bitcoin Knots ${c.url.split('/').pop()}</div>
+                            <div class="contribution-subpanel-grid">
+                                ${c.subItems.map(s => `<a href="${s.url}" target="_blank" rel="noopener noreferrer" class="contribution-link contribution-sublink"><i class="mdi mdi-source-pull" style="margin-right:0.5rem"></i><span>${s.name}</span></a>`).join('')}
+                            </div>
+                        </div>` : '').join('')}
                 </div>
             </div>`).join('');
         container.querySelectorAll('.contribution-header').forEach(header => {
@@ -229,10 +230,11 @@
         });
         container.querySelectorAll('.contribution-subtoggle').forEach(toggle => {
             toggle.addEventListener('click', () => {
-                const sub = toggle.parentElement.querySelector('.contribution-subitems');
+                const key = toggle.dataset.sub;
+                const panel = container.querySelector(`.contribution-subpanel[data-sub="${key}"]`);
                 const chevron = toggle.querySelector('.sub-chevron');
-                const isOpen = sub.style.display !== 'none';
-                sub.style.display = isOpen ? 'none' : 'grid';
+                const isOpen = panel.style.display !== 'none';
+                panel.style.display = isOpen ? 'none' : 'block';
                 chevron.className = isOpen ? 'mdi mdi-chevron-down sub-chevron' : 'mdi mdi-chevron-up sub-chevron';
             });
         });


### PR DESCRIPTION
## Summary
Fixes uneven box heights and ragged wrapping in the Community Contributions section, on both desktop and mobile.

- Use `align-items:stretch` on the contributions grid so every box in a row matches the tallest, regardless of label length (fixes Liana wrapping uneven against Sparrow/Zeus, and Knots/BOLTs/Greenlight).
- Move the Bitcoin Knots PR list out of its grid cell into a full-width panel that drops below the row when expanded, so opening it no longer stretches the neighboring boxes.
- Shorten the collapsed Knots label to "v29.3 Release"; the expanded panel header shows the full release ("11 PRs in Bitcoin Knots v29.3.knots20260508"), derived from the release URL.
- Restyle the PR count as a rounded green pill chip with `nowrap` so it stays on one line and matches the accent theme.

## Notes
- `node --check` passes on `assets/js/main.js`.