### PR TITLE
Fix Bitcoin Infrastructure panel overflow on mobile

### DIFF
--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -44,10 +44,12 @@
 .contribution-header{display:flex;justify-content:space-between;align-items:center;padding:1rem 1.5rem;background-color:rgba(39,174,96,.1);border:1px solid rgba(39,174,96,.3);border-radius:8px;cursor:pointer;transition:all .3s ease}
 .contribution-header:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important}
 .contribution-items{background-color:rgba(255,255,255,.05);border:1px solid rgba(39,174,96,.2);border-top:none;border-bottom-left-radius:8px;border-bottom-right-radius:8px;padding:1rem 1.5rem;display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));gap:.75rem;align-items:stretch}
-.contribution-link{display:flex;align-items:center;padding:.75rem 1rem;background-color:rgba(255,255,255,.08);border:1px solid rgba(39,174,96,.2);border-radius:6px;text-decoration:none;color:#27ae60;transition:all .2s ease;font-size:.95rem;font-weight:500}
+.contribution-link{display:flex;align-items:center;min-width:0;padding:.75rem 1rem;background-color:rgba(255,255,255,.08);border:1px solid rgba(39,174,96,.2);border-radius:6px;text-decoration:none;color:#27ae60;transition:all .2s ease;font-size:.95rem;font-weight:500}
+.contribution-link span,.contribution-subname{min-width:0;overflow-wrap:break-word}
 .contribution-link:hover{background-color:rgba(39,174,96,.15)!important;border-color:rgba(39,174,96,.5)!important;transform:translateX(4px);color:#27ae60}
 .contribution-subtoggle{cursor:pointer}
-.sub-count{margin-left:auto;margin-right:.5rem;font-size:.7rem;font-weight:600;white-space:nowrap;color:#27ae60;background-color:rgba(39,174,96,.15);border:1px solid rgba(39,174,96,.35);border-radius:999px;padding:.15rem .55rem;line-height:1}
+.sub-count{flex-shrink:0;margin-left:auto;margin-right:.5rem;font-size:.7rem;font-weight:600;white-space:nowrap;color:#27ae60;background-color:rgba(39,174,96,.15);border:1px solid rgba(39,174,96,.35);border-radius:999px;padding:.15rem .55rem;line-height:1}
+.contribution-subtoggle>i,.sub-chevron{flex-shrink:0}
 .contribution-subname{color:#27ae60;text-decoration:none}
 .contribution-subname:hover{color:#27ae60;text-decoration:underline}
 .contribution-subpanel{grid-column:1/-1;background-color:rgba(255,255,255,.04);border:1px solid rgba(39,174,96,.2);border-radius:6px;padding:1rem 1.25rem}
@@ -56,5 +58,5 @@
 .contribution-sublink{font-size:.85rem;font-weight:400;background-color:rgba(255,255,255,.06)}
 .resource-card{background-color:rgba(255,255,255,.1);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.1);cursor:pointer;transition:all .4s cubic-bezier(.25,.8,.25,1)}
 .resource-card:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 20px 40px rgba(39,174,96,.3),0 0 20px rgba(39,174,96,.2);background-color:rgba(255,255,255,.15)!important;border-color:rgba(39,174,96,.5)!important}
-@media(max-width:768px){.hero-stats{flex-direction:column;gap:1rem}.hero-stats .stat-item{min-width:200px}.stats-bar{flex-direction:column;gap:1.5rem}.contribution-items{grid-template-columns:1fr}}
+@media(max-width:768px){.hero-stats{flex-direction:column;gap:1rem}.hero-stats .stat-item{min-width:200px}.stats-bar{flex-direction:column;gap:1.5rem}.contribution-items{grid-template-columns:1fr}.contribution-subpanel-grid{grid-template-columns:1fr}.contribution-subpanel{padding:.85rem 1rem}.contribution-subtoggle{order:0}.contribution-subpanel{order:1}.contribution-items>.contribution-link:not(.contribution-subtoggle){order:2}}
 @media(max-width:576px){.hero-text-container{min-height:80px;height:auto;padding:10px 12px}}


### PR DESCRIPTION
## Summary
Fixes the Community Contributions section on mobile, where the Bitcoin Knots PR panel broke out of its box.

- Collapse the Knots PR panel grid to a single column under 768px and reduce its padding, so the 11 PRs stay inside the box instead of overflowing (the inner panel grid kept a 260px min-column that exceeded the available width on phones).
- Allow long PR titles and function names to wrap inside the boxes (`min-width:0` + `overflow-wrap:break-word`).
- Keep the "11 PRs" pill intact with `flex-shrink:0` so its text no longer spills out of the pill on narrow screens.
- Use CSS `order` on mobile so the expanded panel appears directly under the Knots box instead of below Greenlight. Desktop layout is unchanged.

## Notes
- Desktop multi-column layout untouched.
- `node --check` passes on `assets/js/main.js`.