### PR TITLE
Consolidate karlseguin PRs into per-repo expanders

### DIFF
--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -58,5 +58,5 @@
 .contribution-sublink{font-size:.85rem;font-weight:400;background-color:rgba(255,255,255,.06)}
 .resource-card{background-color:rgba(255,255,255,.1);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.1);cursor:pointer;transition:all .4s cubic-bezier(.25,.8,.25,1)}
 .resource-card:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 20px 40px rgba(39,174,96,.3),0 0 20px rgba(39,174,96,.2);background-color:rgba(255,255,255,.15)!important;border-color:rgba(39,174,96,.5)!important}
-@media(max-width:768px){.hero-stats{flex-direction:column;gap:1rem}.hero-stats .stat-item{min-width:200px}.stats-bar{flex-direction:column;gap:1.5rem}.contribution-items{grid-template-columns:1fr}.contribution-subpanel-grid{grid-template-columns:1fr}.contribution-subpanel{padding:.85rem 1rem}.contribution-subtoggle{order:0}.contribution-subpanel{order:1}.contribution-items>.contribution-link:not(.contribution-subtoggle){order:2}}
+@media(max-width:768px){.hero-stats{flex-direction:column;gap:1rem}.hero-stats .stat-item{min-width:200px}.stats-bar{flex-direction:column;gap:1.5rem}.contribution-items{grid-template-columns:1fr}.contribution-subpanel-grid{grid-template-columns:1fr}.contribution-subpanel{padding:.85rem 1rem}}
 @media(max-width:576px){.hero-text-container{min-height:80px;height:auto;padding:10px 12px}}

--- a/assets/css/plain-html.css
+++ b/assets/css/plain-html.css
@@ -54,7 +54,7 @@
 .contribution-subname:hover{color:#27ae60;text-decoration:underline}
 .contribution-subpanel{grid-column:1/-1;background-color:rgba(255,255,255,.04);border:1px solid rgba(39,174,96,.2);border-radius:6px;padding:1rem 1.25rem}
 .contribution-subpanel-title{color:#27ae60;font-weight:600;font-size:.9rem;margin-bottom:.75rem}
-.contribution-subpanel-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:.5rem;align-items:stretch}
+.contribution-subpanel-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:.5rem;align-items:stretch}
 .contribution-sublink{font-size:.85rem;font-weight:400;background-color:rgba(255,255,255,.06)}
 .resource-card{background-color:rgba(255,255,255,.1);backdrop-filter:blur(10px);border:1px solid rgba(255,255,255,.1);cursor:pointer;transition:all .4s cubic-bezier(.25,.8,.25,1)}
 .resource-card:hover{transform:translateY(-10px) scale(1.02);box-shadow:0 20px 40px rgba(39,174,96,.3),0 0 20px rgba(39,174,96,.2);background-color:rgba(255,255,255,.15)!important;border-color:rgba(39,174,96,.5)!important}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -215,13 +215,13 @@
                             <a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-subname">${c.name}</a>
                             <span class="sub-count">${c.subItems.length} PRs</span>
                             <i class="mdi mdi-chevron-down sub-chevron"></i>
-                        </div>` : `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
-                    ${items.map((c, i) => c.subItems ? `<div class="contribution-subpanel" data-sub="${category}::${i}" style="display:none">
+                        </div>
+                        <div class="contribution-subpanel" data-sub="${category}::${i}" style="display:none">
                             <div class="contribution-subpanel-title">${c.subTitle || (c.subItems.length + ' PRs in Bitcoin Knots ' + c.url.split('/').pop())}</div>
                             <div class="contribution-subpanel-grid">
                                 ${c.subItems.map(s => `<a href="${s.url}" target="_blank" rel="noopener noreferrer" class="contribution-link contribution-sublink"><i class="mdi mdi-source-pull" style="margin-right:0.5rem"></i><span>${s.name}</span></a>`).join('')}
                             </div>
-                        </div>` : '').join('')}
+                        </div>` : `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
                 </div>
             </div>`).join('');
         container.querySelectorAll('.contribution-header').forEach(header => {
@@ -244,8 +244,9 @@
                 const panel = container.querySelector(`.contribution-subpanel[data-sub="${key}"]`);
                 const chevron = toggle.querySelector('.sub-chevron');
                 const isOpen = panel.style.display !== 'none';
-                panel.style.display = isOpen ? 'none' : 'block';
-                chevron.className = isOpen ? 'mdi mdi-chevron-down sub-chevron' : 'mdi mdi-chevron-up sub-chevron';
+                container.querySelectorAll('.contribution-subpanel').forEach(el => el.style.display = 'none');
+                container.querySelectorAll('.sub-chevron').forEach(el => el.className = 'mdi mdi-chevron-down sub-chevron');
+                if (!isOpen) { panel.style.display = 'block'; chevron.className = 'mdi mdi-chevron-up sub-chevron'; }
             });
         });
     }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -84,10 +84,15 @@
                 { name: "Routstr Chat - Invoice History & Persistence", url: "https://github.com/Routstr/routstr-chat/pull/67" }
             ],
             "Developer Tools": [
-                { name: "http.zig - Fix Event Loop Use-After-Free on Connection Close", url: "https://github.com/karlseguin/http.zig/pull/216" },
-                { name: "http.zig - Fix Recv/Disown Use-After-Free Race", url: "https://github.com/karlseguin/http.zig/pull/214" },
-                { name: "http.zig - Fix Lost Websocket Read on Re-arm", url: "https://github.com/karlseguin/http.zig/pull/212" },
-                { name: "websocket.zig - Fix TLS Client Read-Timeout Panic", url: "https://github.com/karlseguin/websocket.zig/pull/103" },
+                { name: "http.zig - Memory-Safety & Reliability Fixes", url: "https://github.com/karlseguin/http.zig", subTitle: "3 merged PRs in karlseguin/http.zig", subItems: [
+                    { name: "Fix Event Loop Use-After-Free on Connection Close", url: "https://github.com/karlseguin/http.zig/pull/216" },
+                    { name: "Fix Recv/Disown Use-After-Free Race", url: "https://github.com/karlseguin/http.zig/pull/214" },
+                    { name: "Fix Lost Websocket Read on Re-arm", url: "https://github.com/karlseguin/http.zig/pull/212" }
+                ] },
+                { name: "websocket.zig - Client Timeout & Safety Fixes", url: "https://github.com/karlseguin/websocket.zig", subTitle: "2 merged PRs in karlseguin/websocket.zig", subItems: [
+                    { name: "Bounded Connect & TLS Handshake Timeout", url: "https://github.com/karlseguin/websocket.zig/pull/108" },
+                    { name: "Fix TLS Client Read-Timeout Panic", url: "https://github.com/karlseguin/websocket.zig/pull/103" }
+                ] },
                 { name: "Goose - Auto-Compact on Context Limit", url: "https://github.com/block/goose/pull/3635" },
                 { name: "Goose - Enable Zero-Config Providers in GUI", url: "https://github.com/block/goose/pull/3378" }
             ],
@@ -212,7 +217,7 @@
                             <i class="mdi mdi-chevron-down sub-chevron"></i>
                         </div>` : `<a href="${c.url}" target="_blank" rel="noopener noreferrer" class="contribution-link"><i class="mdi mdi-github" style="margin-right:0.5rem"></i><span>${c.name}</span></a>`).join('')}
                     ${items.map((c, i) => c.subItems ? `<div class="contribution-subpanel" data-sub="${category}::${i}" style="display:none">
-                            <div class="contribution-subpanel-title">${c.subItems.length} PRs in Bitcoin Knots ${c.url.split('/').pop()}</div>
+                            <div class="contribution-subpanel-title">${c.subTitle || (c.subItems.length + ' PRs in Bitcoin Knots ' + c.url.split('/').pop())}</div>
                             <div class="contribution-subpanel-grid">
                                 ${c.subItems.map(s => `<a href="${s.url}" target="_blank" rel="noopener noreferrer" class="contribution-link contribution-sublink"><i class="mdi mdi-source-pull" style="margin-right:0.5rem"></i><span>${s.name}</span></a>`).join('')}
                             </div>


### PR DESCRIPTION
Groups the http.zig and websocket.zig contributions into two expandable per-repo entries instead of listing each PR as a separate line, so the Developer Tools section shows depth-per-project rather than repeating one maintainer's name.

- http.zig: 3 memory-safety/reliability fixes (#216, #214, #212) under one expander.
- websocket.zig: 2 client timeout/safety fixes, folding in the newly merged #108 alongside #103.
- Adds an optional `subTitle` field to the contributions renderer and falls back to the existing Bitcoin Knots label, so Knots is unchanged.