### PR TITLE
Refocus Kyle bio on open source work and list shipped dev tools

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -44,14 +44,11 @@
             ],
             "Apps & Tools": [
                 { name: "wisp", description: "Fast, lightweight self-hostable Nostr relay with spider mode that syncs notes from people you follow.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
-                { name: "puck", description: "Nostr Wallet Connect (NIP-47) server with an LNbits backend for invoices and payments.", language: "Zig", url: "https://github.com/privkeyio/puck" },
-                { name: "whisper", description: "Encrypted Nostr DM pipe (NIP-17 + NIP-44) with a Unix-style CLI and TUI.", language: "C", url: "https://github.com/privkeyio/whisper" },
                 { name: "Taproot Assets Gateway", description: "REST proxy that makes Lightning Labs' tapd usable from web apps with CORS and simplified macaroon auth.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" },
                 { name: "noz", description: "Small, fast Nostr command-line tool for signing, publishing, querying, and decoding NIP-19 entities.", language: "Zig", url: "https://github.com/privkeyio/noz" }
             ],
             "Developer Tools": [
-                { name: "bosun", description: "Tracks PR review and triage status across Bitcoin forks. Live at bosun.privkey.io.", language: "Python", url: "https://github.com/privkeyio/bosun" },
-                { name: "nostr-bench", description: "Benchmarking tool for measuring Nostr relay throughput and latency.", language: "Zig", url: "https://github.com/privkeyio/nostr-bench" }
+                { name: "bosun", description: "Tracks PR review and triage status across Bitcoin forks. Live at bosun.privkey.io.", language: "Python", url: "https://github.com/privkeyio/bosun" }
             ]
         },
         contributions: {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -46,7 +46,13 @@
                 { name: "wisp", description: "Fast, lightweight self-hostable Nostr relay with spider mode that syncs notes from people you follow.", language: "Zig", url: "https://github.com/privkeyio/wisp" },
                 { name: "puck", description: "Nostr Wallet Connect (NIP-47) server with an LNbits backend for invoices and payments.", language: "Zig", url: "https://github.com/privkeyio/puck" },
                 { name: "whisper", description: "Encrypted Nostr DM pipe (NIP-17 + NIP-44) with a Unix-style CLI and TUI.", language: "C", url: "https://github.com/privkeyio/whisper" },
-                { name: "Taproot Assets Gateway", description: "REST proxy that makes Lightning Labs' tapd usable from web apps with CORS and simplified macaroon auth.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" }
+                { name: "Taproot Assets Gateway", description: "REST proxy that makes Lightning Labs' tapd usable from web apps with CORS and simplified macaroon auth.", language: "Rust", url: "https://github.com/privkeyio/taproot-assets-rest-gateway" },
+                { name: "noz", description: "Small, fast Nostr command-line tool for signing, publishing, querying, and decoding NIP-19 entities.", language: "Zig", url: "https://github.com/privkeyio/noz" }
+            ],
+            "Developer Tools": [
+                { name: "bosun", description: "Tracks PR review and triage status across Bitcoin forks. Live at bosun.privkey.io.", language: "Python", url: "https://github.com/privkeyio/bosun" },
+                { name: "nostr-bench", description: "Benchmarking tool for measuring Nostr relay throughput and latency.", language: "Zig", url: "https://github.com/privkeyio/nostr-bench" },
+                { name: "evolve-mcp", description: "MCP server for agent self-improvement, evolving prompts with genetic algorithms and safety validation.", language: "Python", url: "https://github.com/privkeyio/evolve-mcp" }
             ]
         },
         contributions: {
@@ -101,7 +107,7 @@
         },
         team: [
             { image: "assets/images/william_profile.png", title: "William K. Santiago", desc: "FOUNDER & CEO", bio: "30+ years in cybersecurity. Pioneered institutional Bitcoin infrastructure starting in 2011. Directed enterprise Bitcoin deployments for large corporations. BS in Management Information Systems – University of South Florida.", mobileBio: ["30-year cybersecurity veteran", "Bitcoin infrastructure since 2011", "Fortune 500 enterprise security"], linkedIn: "https://linkedin.com/in/wksantiago", twitter: "https://x.com/williamsantiago" },
-            { image: "assets/images/kyle_profile.png", title: "Kyle W. Santiago", desc: "FOUNDER & CTO", bio: "Over a decade of cryptocurrency, software engineering, and cybersecurity expertise since 2011. BS & MS in Cybersecurity from the University of South Florida. Led integrations for Chainlink Labs and scaled institutional digital asset platforms.", mobileBio: ["10+ years crypto & cybersecurity", "BS & MS in Cybersecurity, USF", "Full stack development for 7+ years"], linkedIn: "https://linkedin.com/in/kwsantiago", twitter: "https://x.com/kwsantiago" }
+            { image: "assets/images/kyle_profile.png", title: "Kyle W. Santiago", desc: "FOUNDER & CTO", bio: "Open-source systems engineer building in Rust, Zig, and C. Contributor to Bitcoin Core, Bitcoin Knots, BDK, and rust-miniscript, and author of PrivKey's Keep signing stack, Wisp relay, and Nostr protocol libraries. BS & MS in Cybersecurity from the University of South Florida.", mobileBio: ["Bitcoin Core & Knots contributor", "Systems work in Rust, Zig, and C", "BS & MS in Cybersecurity, USF"], linkedIn: "https://linkedin.com/in/kwsantiago", twitter: "https://x.com/kwsantiago" }
         ],
         resources: []
     };

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,8 +51,7 @@
             ],
             "Developer Tools": [
                 { name: "bosun", description: "Tracks PR review and triage status across Bitcoin forks. Live at bosun.privkey.io.", language: "Python", url: "https://github.com/privkeyio/bosun" },
-                { name: "nostr-bench", description: "Benchmarking tool for measuring Nostr relay throughput and latency.", language: "Zig", url: "https://github.com/privkeyio/nostr-bench" },
-                { name: "evolve-mcp", description: "MCP server for agent self-improvement, evolving prompts with genetic algorithms and safety validation.", language: "Python", url: "https://github.com/privkeyio/evolve-mcp" }
+                { name: "nostr-bench", description: "Benchmarking tool for measuring Nostr relay throughput and latency.", language: "Zig", url: "https://github.com/privkeyio/nostr-bench" }
             ]
         },
         contributions: {


### PR DESCRIPTION
## Team bio

Kyle's bio was framed around cryptocurrency and past employer work. Reframed it around open-source systems engineering: languages used, upstream projects contributed to, and the PrivKey projects he authored. Mobile bullets updated to match.

## Products

Trimmed the list to projects that are actively maintained, so the section stays a signal rather than a catalog.

Removed:

- `puck` and `whisper` — no commits or releases since March; both still have open issues and no tagged version.

Added:

- `noz` (Zig Nostr CLI, tagged releases, companion to `libnostr-z`) under Apps & Tools
- New "Developer Tools" group with `bosun`, which runs live at bosun.privkey.io

Also considered and left off: `nostr-bench` (niche, low activity), `keep-node` (README states MVP in progress), `warden` (no releases).

Verified `node --check` passes and every remaining product and ecosystem URL on the page resolves.
