### PR TITLE
Add GitHub links to team cards and fix social icon alignment

### DIFF
--- a/assets/css/mobile-responsive-fixes.css
+++ b/assets/css/mobile-responsive-fixes.css
@@ -709,14 +709,17 @@
 }
 
 .social-icons-list .social-icon svg {
-  width: 20px;
-  height: 20px;
-  min-width: 20px;
-  min-height: 20px;
+  width: 20px !important;
+  height: 20px !important;
+  min-width: 20px !important;
+  min-height: 20px !important;
+  display: block !important;
 }
 
 .social-icons-list .social-icon i {
-  font-size: 20px;
+  font-size: 20px !important;
+  line-height: 1 !important;
+  display: block !important;
 }
 
 /* Mobile fix for social icons fitting in footer card */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -117,8 +117,8 @@
             ],
         },
         team: [
-            { image: "assets/images/william_profile.jpg", title: "William K. Santiago", desc: "FOUNDER & CEO", bio: "30+ years in cybersecurity. Pioneered institutional Bitcoin infrastructure starting in 2011. Directed enterprise Bitcoin deployments for large corporations. BS in Management Information Systems, University of South Florida.", mobileBio: ["30-year cybersecurity veteran", "Bitcoin infrastructure since 2011", "Fortune 500 enterprise security"], linkedIn: "https://linkedin.com/in/wksantiago", twitter: "https://x.com/williamsantiago" },
-            { image: "assets/images/kyle_profile.jpg", title: "Kyle W. Santiago", desc: "FOUNDER & CTO", bio: "Open-source systems engineer building in Rust, Zig, and C. Contributor to Bitcoin Core, Bitcoin Knots, BDK, and rust-miniscript, and author of PrivKey's Keep signing stack, Wisp relay, and Nostr protocol libraries. BS & MS in Cybersecurity from the University of South Florida.", mobileBio: ["Bitcoin Core & Knots contributor", "Systems work in Rust, Zig, and C", "BS & MS in Cybersecurity, USF"], linkedIn: "https://linkedin.com/in/kwsantiago", twitter: "https://x.com/kwsantiago" }
+            { image: "assets/images/william_profile.jpg", title: "William K. Santiago", desc: "FOUNDER & CEO", bio: "30+ years in cybersecurity. Pioneered institutional Bitcoin infrastructure starting in 2011. Directed enterprise Bitcoin deployments for large corporations. BS in Management Information Systems, University of South Florida.", mobileBio: ["30-year cybersecurity veteran", "Bitcoin infrastructure since 2011", "Fortune 500 enterprise security"], linkedIn: "https://linkedin.com/in/wksantiago", twitter: "https://x.com/williamsantiago", github: "https://github.com/wksantiago" },
+            { image: "assets/images/kyle_profile.jpg", title: "Kyle W. Santiago", desc: "FOUNDER & CTO", bio: "Open-source systems engineer building in Rust, Zig, and C. Contributor to Bitcoin Core, Bitcoin Knots, BDK, and rust-miniscript, and author of PrivKey's Keep signing stack, Wisp relay, and Nostr protocol libraries. BS & MS in Cybersecurity from the University of South Florida.", mobileBio: ["Bitcoin Core & Knots contributor", "Systems work in Rust, Zig, and C", "BS & MS in Cybersecurity, USF"], linkedIn: "https://linkedin.com/in/kwsantiago", twitter: "https://x.com/kwsantiago", github: "https://github.com/kwsantiago" }
         ],
         resources: []
     };
@@ -283,6 +283,7 @@
                     <div class="row"><h4 class="team-name">${t.title}</h4></div>
                     <div class="row margin-social-icon"><span class="text-uppercase team-designation">${t.desc}</span></div>
                     <ul class="social-icons-list">
+                        ${t.github ? `<li class="list-inline-item"><a href="${t.github}" class="social-icon" target="_blank" rel="noopener noreferrer" aria-label="${t.title} on GitHub"><i class="mdi mdi-github-circle"></i></a></li>` : ''}
                         ${t.linkedIn ? `<li class="list-inline-item"><a href="${t.linkedIn}" class="social-icon" target="_blank" rel="noopener noreferrer"><i class="mdi mdi-linkedin"></i></a></li>` : ''}
                         ${t.twitter ? `<li class="list-inline-item"><a href="${t.twitter}" class="social-icon" target="_blank" rel="noopener noreferrer"><svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a></li>` : ''}
                     </ul>

--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@
                                 <li class="list-inline-item"><a href="https://x.com/privkey_io" class="social-icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg></a></li>
                                 <li class="list-inline-item"><a href="https://www.linkedin.com/company/privkeyllc/" class="social-icon"><i class="mdi mdi-linkedin"></i></a></li>
                                 <li class="list-inline-item"><a href="https://www.instagram.com/privkey_io/" class="social-icon"><i class="mdi mdi-instagram"></i></a></li>
-                                <li class="list-inline-item"><a href="https://github.com/privkeyio" class="social-icon"><i class="mdi mdi-github-box"></i></a></li>
+                                <li class="list-inline-item"><a href="https://github.com/privkeyio" class="social-icon"><i class="mdi mdi-github-circle"></i></a></li>
                             </ul>
                             <p class="copy-rights mb-0" style="color:#B3B3B3;font-size:0.95rem"><span id="current-year"></span> © PrivKey LLC. All rights reserved.</p>
                         </div>


### PR DESCRIPTION
## Alignment

`essential-only.css` forced `.social-icon i { font-size: 2rem !important }` on the icon-font glyphs while `plain-html.css` pinned the X inline SVG to 24px, inside a 32px flex box. LinkedIn rendered 8px larger than X and sat high on its font baseline.

Both are now pinned to 20px with `line-height: 1` and `display: block`, sharing the same optical center. The rule lives on `.social-icons-list`, so it fixes the footer Follow Us row as well.

## GitHub links

Added to both team cards, first in the row: github.com/kwsantiago and github.com/wksantiago.

## Icon consistency

Footer GitHub icon swapped from `mdi-github-box` to `mdi-github-circle`, matching the plain glyphs beside it and the new team icons.

Verified by rendering in headless Chromium: team and footer icon rows both even, GitHub links present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub links to team member profiles when available.
  * Updated the footer GitHub icon for improved visual consistency.

* **Bug Fixes**
  * Consolidated responsive styling while preserving mobile navigation, hero layouts, footer behavior, text wrapping, and team bio display across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->