### PR TITLE
Add LDK security-disclosure credit to Lightning contributions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -84,6 +84,7 @@
                 { name: "Liana - User-Agent Header Support", url: "https://github.com/wizardsardine/liana/pull/1902" }
             ],
             "Lightning": [
+                { name: "LDK (Rust Lightning) - Reported Security Fixes (v0.2.5)", url: "https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/releases/tag/v0.2.5" },
                 { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" },
                 { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" }
             ],


### PR DESCRIPTION
Adds an entry under the Lightning category of Community Contributions crediting a reported and shipped security disclosure to the Lightning Dev Kit (rust-lightning), fixed in its v0.2.5 release. Verified locally: the Lightning category now shows the new entry and the contribution totals update accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an LDK (Rust Lightning) contribution entry under Lightning contributions.
  * Linked the entry to the v0.2.5 release and highlighted its reported security fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->