### PR TITLE
Fix per-category contribution counts to include bundled PRs

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -233,7 +233,7 @@
         container.innerHTML = Object.entries(DATA.contributions).map(([category, items]) => `
             <div style="margin-bottom:1rem">
                 <div class="contribution-header" data-category="${category}">
-                    <div><h5 class="text-white mb-0">${category}</h5><small class="text-white-50">${items.length} contributions</small></div>
+                    <div><h5 class="text-white mb-0">${category}</h5><small class="text-white-50">${items.reduce((n, c) => n + (c.subItems ? c.subItems.length : 1), 0)} contributions</small></div>
                     <i class="mdi mdi-chevron-down" style="color:#27ae60;font-size:1.5rem"></i>
                 </div>
                 <div class="contribution-items" data-category="${category}" style="display:none">


### PR DESCRIPTION
The Community Contributions total counts individual PRs (expanding bundled sub-items), but each category header counted only top-level entries. That made a category like Nostr Apps show "4 contributions" even though one entry bundles 6 merged PRs, contradicting both the "6 PRs" label beside it and the overall total. This makes the per-category count expand bundled sub-items the same way the total does, so category counts are consistent with the sub-item labels and now sum to the overall total. Verified locally: category counts sum to the displayed total.