### PR TITLE
Add LDK blinded-path fee fix to Lightning contributions

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -101,6 +101,7 @@
             ],
             "Lightning": [
                 { name: "LDK (Rust Lightning) - Reported Security Fixes (v0.2.5)", url: "https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/releases/tag/v0.2.5" },
+                { name: "LDK (Rust Lightning) - Fix Blinded Path Over-100% Proportional Fee Calculation", url: "https://git.rust-bitcoin.org/lightningdevkit/rust-lightning/pulls/4836" },
                 { name: "Lightning BOLTs - Add Security Policy", url: "https://github.com/lightning/bolts/pull/1278" },
                 { name: "Greenlight - Switch to uv Package Manager", url: "https://github.com/Blockstream/greenlight/pull/612" }
             ],


### PR DESCRIPTION
Adds a merged Lightning Dev Kit (rust-lightning) contribution under the Lightning category of Community Contributions: a fix for blinded-path fee calculation with over-100% proportional fees. Verified the contribution is merged before adding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Lightning Development Kit contribution recognizing a fix for proportional fee calculations exceeding 100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->